### PR TITLE
svector.h explanation + questions about template.h

### DIFF
--- a/g_src/svector.h
+++ b/g_src/svector.h
@@ -2,25 +2,38 @@
 #ifndef SVECTOR_H
 #define SVECTOR_H
 
+/**
+ * svector is essentially a clone of std::vector,
+ * forwarding the allocator template parameter
+ * (note: identical default to std::vector),
+ * but implementing an insert-by-index instead of
+ * iterator method for convenience.
+ * 
+ * this templated container appears to be used primarily for
+ * c-strings, but has a number of helper-method implemented
+ * to operate on index-types.
+*/
+
 #include <vector>
 #include <memory>
 
 template <class T, class A = std::allocator<T> >
 class svector : public std::vector<T, A> {
-        public:
-                using std::vector<T, A>::erase;
-                using std::vector<T,A>::begin;
-                using std::vector<T,A>::insert;
-                void erase(typename std::vector<T, A>::size_type i) {
-                        erase(begin() + i);
-                }
-                void insert(typename std::vector<T, A>::size_type i, const T &v) {
+public:
+        using std::vector<T,A>::erase;
+        using std::vector<T,A>::begin;
+        using std::vector<T,A>::insert;
 
-                        insert(begin() + i, v);
-                }
-                void insert(typename std::vector<T,A>::size_type i,T &&v)
-                {
-                    insert(begin()+i,std::move(v));
-                  }
+        void erase(typename std::vector<T, A>::size_type i) {
+                erase(begin() + i);
+        }
+        void insert(typename std::vector<T, A>::size_type i, const T &v) {
+                insert(begin() + i, v);
+        }
+        void insert(typename std::vector<T,A>::size_type i, T &&v){
+                insert(begin() + i, std::move(v));
+        }
+
 };
+
 #endif


### PR DESCRIPTION
This PR just contains some questions about the implementations in template.h. There are some unused local variables and a lot of unnecessary downcasts. Also, some of the binary searches that happen here imply that you want a contiguous but sorted piece of memory for the index svectors. It could be the case that you actually need this, but if not there are better containers to deal with the sorted unique / non-unique index sets.

Also a lot of the return value downcasts can probably be removed, UNLESS you are storing them in raw pointer arrays in which case you must cast (but I don't know who consumes these methods, so I only made recs).

In general it is probably prudent to use the size_t type.

commit-msg: added commentary for the svector.h, template.h implementations. Note that any concrete code recommendations can't be compiled and therefore tested. Prudent utilization of std::algorithm and range-based for loop can greatly improve legibility. A lot of unnecessary downcasts are happening for the vector::size_type, and general utilization of a contiguous sorted vector could be reconsidered for performance purposes. There is a trade-off when requiring both things.