### PR TITLE
Constructors: 

### DIFF
--- a/g_src/ViewBase.h
+++ b/g_src/ViewBase.h
@@ -17,29 +17,17 @@ struct world_gen_param_valuest;
 
 void draw_nineslice(int32_t* slice, int sy, int sx, int ey, int ex, bool override=false);
 
-struct scrollbarst
-{
-    int32_t sel;
-    int32_t sel_min;
-    int32_t sel_max;
-    int32_t page_size;
-    int32_t print_sy;
-    int32_t print_ey;
+struct scrollbarst {
 
-    int32_t scroller_sy;
-    int32_t scroller_ey;
+    int32_t sel = 0;
+    int32_t sel_min = 0;
+    int32_t sel_max = 0;
+    int32_t page_size; // missing initial value
+    int32_t print_sy = 0;
+    int32_t print_ey = 0;
 
-
-    scrollbarst()
-    {
-        sel = 0;
-        sel_min = 0;
-        sel_max = 0;
-        print_sy = 0;
-        print_ey = 0;
-        scroller_sy = 0;
-        scroller_ey = 0;
-    }
+    int32_t scroller_sy = 0;
+    int32_t scroller_ey = 0;
 
     void init(int32_t n_sel, int32_t n_smn, int32_t n_smx, int32_t npnm, int32_t psy, int32_t pey)
     {
@@ -164,9 +152,7 @@ struct scrollbarst
     bool handle_events(std::set<InterfaceKey>& events, int32_t& scroll_position, bool& scrolling);
 };
 
-class abstract_interfacest
-{
-public:
+struct abstract_interfacest {
     virtual void feed(std::set<InterfaceKey> &events) = 0;
     virtual void logic() = 0;
     virtual void render() = 0;
@@ -550,28 +536,26 @@ enum InterfaceBreakdownTypes
 	INTERFACE_BREAKDOWNNUM
 };
 
-class viewscreenst : abstract_interfacest
-{
-	public:
-		viewscreenst *child;
-		viewscreenst *parent;
-		char breakdownlevel;
+struct viewscreenst : abstract_interfacest {
+	viewscreenst *child;
+	viewscreenst *parent;
+	char breakdownlevel;
 
-		char option_key_pressed;
-        widgets::container widgets;
-        virtual void feed(std::set<InterfaceKey>& events) { widgets.feed(events); }
-        virtual void logic() { widgets.logic(); }
-        virtual void render() { widgets.render(); }
-        virtual void resize(int w, int h){}
+	char option_key_pressed;
+    widgets::container widgets;
+    virtual void feed(std::set<InterfaceKey>& events) { widgets.feed(events); }
+    virtual void logic() { widgets.logic(); }
+    virtual void render() { widgets.render(); }
+    virtual void resize(int w, int h){}
 
 #ifdef CURSES_MOVIES
-		virtual char movies_okay(){return 1;}
+	virtual char movies_okay(){return 1;}
 #endif
 
-		virtual void set_port_flags();
+	virtual void set_port_flags();
 
-		viewscreenst();
-		virtual ~viewscreenst(){}
+	viewscreenst();
+	virtual ~viewscreenst(){}
 };
 
 #endif

--- a/g_src/command_line.h
+++ b/g_src/command_line.h
@@ -1,25 +1,14 @@
-class command_linest
-{
-	public:
-		string original;
-		stringvectst arg_vect;
+struct command_linest {
+	string original;
+	stringvectst arg_vect;
 
-		long gen_id;
-		unsigned long world_seed;
-		char use_seed;
-		string world_param;
-		char use_param;
+	long gen_id = -1;
+	unsigned long world_seed;
+	char use_seed = 0;
+	string world_param;
+	char use_param = 0;
 
-
-
-		void init(const string &str);
-		char grab_arg(string &source,long &pos);
-		void handle_arg(string &arg);
-
-		command_linest()
-			{
-			gen_id=-1;
-			use_seed=0;
-			use_param=0;
-			}
+	void init(const string &str);
+	char grab_arg(string &source,long &pos);
+	void handle_arg(string &arg);
 };

--- a/g_src/enabler.h
+++ b/g_src/enabler.h
@@ -95,135 +95,137 @@ using std::queue;
 
 #define GAME_TITLE_STRING "Dwarf Fortress"
 
-class pstringst
-{
- public:
+struct pstringst {
   string dat;
 };
 
-class stringvectst
-{
-	public:
-		svector<pstringst *> str;
+struct stringvectst {
+	svector<pstringst *> str;
 
-		void add_string(const string &st)
+	void add_string(const string &st)
+		{
+		pstringst *newp=new pstringst;
+			newp->dat=st;
+		str.push_back(newp);
+		}
+
+	long add_unique_string(const string &st)
+		{
+		long i;
+		for(i=(long)str.size()-1;i>=0;i--)
+			{
+			if(str[i]->dat==st)return i;
+			}
+		add_string(st);
+		return (long)str.size()-1;
+		}
+
+	void add_string(const char *st)
+		{
+		if(st!=NULL)
 			{
 			pstringst *newp=new pstringst;
 				newp->dat=st;
 			str.push_back(newp);
 			}
+		}
 
-		long add_unique_string(const string &st)
+	void insert_string(long k,const string &st)
+		{
+		pstringst *newp=new pstringst;
+			newp->dat=st;
+		if(str.size()>k)str.insert(k,newp);
+		else str.push_back(newp);
+		}
+
+	~stringvectst()
+		{
+		clean();
+		}
+
+	void clean()
+		{
+		while(str.size()>0)
 			{
-			long i;
-			for(i=(long)str.size()-1;i>=0;i--)
+			delete str[0];
+			str.erase(0);
+			}
+		}
+
+	void read_file(file_compressorst &filecomp,long loadversion)
+		{
+		int32_t dummy;
+		filecomp.read_file(dummy);
+		str.resize(dummy);
+
+		long s;
+		for(s=0;s<dummy;s++)
+			{
+			str[s]=new pstringst;
+			filecomp.read_file(str[s]->dat);
+			}
+		}
+	void write_file(file_compressorst &filecomp)
+		{
+		int32_t dummy=(int32_t)str.size();
+		filecomp.write_file(dummy);
+
+		long s;
+		for(s=0;s<dummy;s++)
+			{
+			filecomp.write_file(str[s]->dat);
+			}
+		}
+
+	void copy_from(const stringvectst &src)
+		{
+		clean();
+
+		str.resize(src.str.size());
+
+		long s;
+		for(s=(long)src.str.size()-1;s>=0;s--)
+			{
+			str[s]=new pstringst;
+				str[s]->dat=src.str[s]->dat;
+			}
+		}
+
+	bool has_string(const string &st)
+		{
+		long i;
+		for(i=(long)str.size()-1;i>=0;i--)
+			{
+			if(str[i]->dat==st)return true;
+			}
+		return false;
+		}
+
+	void remove_string(const string &st)
+		{
+		long i;
+		for(i=(long)str.size()-1;i>=0;i--)
+			{
+			if(str[i]->dat==st)
 				{
-				if(str[i]->dat==st)return i;
-				}
-			add_string(st);
-			return (long)str.size()-1;
-			}
-
-		void add_string(const char *st)
-			{
-			if(st!=NULL)
-				{
-				pstringst *newp=new pstringst;
-					newp->dat=st;
-				str.push_back(newp);
-				}
-			}
-
-		void insert_string(long k,const string &st)
-			{
-			pstringst *newp=new pstringst;
-				newp->dat=st;
-			if(str.size()>k)str.insert(k,newp);
-			else str.push_back(newp);
-			}
-
-		~stringvectst()
-			{
-			clean();
-			}
-
-		void clean()
-			{
-			while(str.size()>0)
-				{
-				delete str[0];
-				str.erase(0);
-				}
-			}
-
-		void read_file(file_compressorst &filecomp,long loadversion)
-			{
-			int32_t dummy;
-			filecomp.read_file(dummy);
-			str.resize(dummy);
-
-			long s;
-			for(s=0;s<dummy;s++)
-				{
-				str[s]=new pstringst;
-				filecomp.read_file(str[s]->dat);
-				}
-			}
-		void write_file(file_compressorst &filecomp)
-			{
-			int32_t dummy=(int32_t)str.size();
-			filecomp.write_file(dummy);
-
-			long s;
-			for(s=0;s<dummy;s++)
-				{
-				filecomp.write_file(str[s]->dat);
-				}
-			}
-
-		void copy_from(const stringvectst &src)
-			{
-			clean();
-
-			str.resize(src.str.size());
-
-			long s;
-			for(s=(long)src.str.size()-1;s>=0;s--)
-				{
-				str[s]=new pstringst;
-					str[s]->dat=src.str[s]->dat;
-				}
-			}
-
-		bool has_string(const string &st)
-			{
-			long i;
-			for(i=(long)str.size()-1;i>=0;i--)
-				{
-				if(str[i]->dat==st)return true;
-				}
-			return false;
-			}
-
-		void remove_string(const string &st)
-			{
-			long i;
-			for(i=(long)str.size()-1;i>=0;i--)
-				{
-				if(str[i]->dat==st)
-					{
-					delete str[i];
-					str.erase(i);
-					}
+				delete str[i];
+				str.erase(i);
 				}
 			}
+		}
 
-		void operator=(stringvectst &two);
+	void operator=(stringvectst &two);
 };
 
-class flagarrayst
-{
-	public:
+class flagarrayst {
+
+  private:
+
+    unsigned char *array;
+    int32_t slotnum;
+  
+  public:
+
 		flagarrayst()
 			{
 			slotnum=0;
@@ -337,10 +339,6 @@ class flagarrayst
 				slotnum=0;
 				}
 			}
-
-	private:
-		unsigned char *array;
-		int32_t slotnum;
 };
 
 #ifdef ENABLER

--- a/g_src/graphics.h
+++ b/g_src/graphics.h
@@ -16,7 +16,13 @@ using std::string;
 #define PALETTE_COLORNUM 18
 
 struct palettest {
-	uint8_t color[PALETTE_COLORNUM*3]{128};
+	uint8_t color[PALETTE_COLORNUM*3];
+
+	palettest()
+		{
+		int32_t c;
+		for(c=0;c<PALETTE_COLORNUM*3;++c)color[c]=128;
+		}
 
 	void copy_from(palettest &src)
 		{

--- a/g_src/graphics.h
+++ b/g_src/graphics.h
@@ -15,15 +15,9 @@ using std::string;
 
 #define PALETTE_COLORNUM 18
 
-struct palettest
-{
-	uint8_t color[PALETTE_COLORNUM*3];
+struct palettest {
+	uint8_t color[PALETTE_COLORNUM*3]{128};
 
-	palettest()
-		{
-		int32_t c;
-		for(c=0;c<PALETTE_COLORNUM*3;++c)color[c]=128;
-		}
 	void copy_from(palettest &src)
 		{
 		std::memmove(color,src.color,sizeof(uint8_t)*PALETTE_COLORNUM*3);
@@ -1409,9 +1403,9 @@ enum GraphicsRampType
 #define GRAPHIC_VIEWPORT_FLAG_ACTIVE BIT1
 #define GRAPHIC_VIEWPORT_FLAG_SHOW_LIQUID_NUMBERS BIT2
 
-struct graphic_viewportst
-{
-	uint32_t flag;
+struct graphic_viewportst {
+
+	uint32_t flag = 0;
 
 	int32_t dim_x,dim_y;
 	int32_t clipx[2],clipy[2];
@@ -1481,7 +1475,6 @@ struct graphic_viewportst
 
 	graphic_viewportst()
 		{
-		flag=0;
 		screentexpos=NULL;
 		screentexpos_background=NULL;
 		screentexpos_background_two=NULL;
@@ -2551,8 +2544,8 @@ typedef int32_t TextureBridge;
 	#define VIEWPORT_SPATTER_FLAG_FIRE_FRAME_4 (BIT29|BIT30)
 #define VIEWPORT_SPATTER_FLAG_ACCEPTS_SPATTER BIT32
 
-struct interface_setst
-{
+struct interface_setst {
+
 	int32_t texpos_calendar_month[12][3];
 	int32_t texpos_calendar_day_past[3];
 	int32_t texpos_calendar_day_current[3];

--- a/g_src/init.cpp
+++ b/g_src/init.cpp
@@ -47,24 +47,6 @@ extern graphicst gps;
 
 int32_t convert_raw_to_ascii_texpos(uint8_t tile,uint8_t color_f,uint8_t color_b,uint8_t color_br);
 
-init_displayst::init_displayst()
-{
-	flag.set_size_on_flag_num(INIT_DISPLAY_FLAGNUM);
-		flag.add_flag(INIT_DISPLAY_FLAG_USE_GRAPHICS);
-		flag.add_flag(INIT_DISPLAY_FLAG_INTERFACE_SCALING_TO_DESIRED_HEIGHT_WIDTH);
-
-	interface_scaling_desired_width=170;
-	interface_scaling_desired_height=64;
-	interface_scaling_percentage=100;
-
-	windowed=INIT_DISPLAY_WINDOW_TRUE;
-	filter_mode = InitDisplayFilterMode::AUTO;
-
-	partial_print_count=0;
-
-	max_interface_percentage=100;
-}
-
 void initst::begin()
 {
   static bool called = false;

--- a/g_src/init.h
+++ b/g_src/init.h
@@ -3,38 +3,35 @@
 
 #include "enabler.h"
 
-class init_fontst
-{
-	public:
-		long basic_font_texpos[256];
-		long small_font_texpos[256];
-		long large_font_texpos[256];
-		long basic_font_datapos[256];
-		long small_font_datapos[256];
-		long large_font_datapos[256];
+struct init_fontst {
+	long basic_font_texpos[256];
+	long small_font_texpos[256];
+	long large_font_texpos[256];
+	long basic_font_datapos[256];
+	long small_font_datapos[256];
+	long large_font_datapos[256];
 
-		long basic_font_texpos_top[256];
-		long small_font_texpos_top[256];
-		long large_font_texpos_top[256];
-		long basic_font_texpos_bot[256];
-		long small_font_texpos_bot[256];
-		long large_font_texpos_bot[256];
+	long basic_font_texpos_top[256];
+	long small_font_texpos_top[256];
+	long large_font_texpos_top[256];
+	long basic_font_texpos_bot[256];
+	long small_font_texpos_bot[256];
+	long large_font_texpos_bot[256];
 
-		float basic_font_adjx;
-		float basic_font_adjy;
-		float small_font_adjx;
-		float small_font_adjy;
-		float large_font_adjx;
-		float large_font_adjy;
-		long basic_font_dispx;
-		long basic_font_dispy;
-		long small_font_dispx;
-		long small_font_dispy;
-		long large_font_dispx;
-		long large_font_dispy;
+	float basic_font_adjx;
+	float basic_font_adjy;
+	float small_font_adjx;
+	float small_font_adjy;
+	float large_font_adjx;
+	float large_font_adjy;
+	long basic_font_dispx;
+	long basic_font_dispy;
+	long small_font_dispx;
+	long small_font_dispy;
+	long large_font_dispx;
+	long large_font_dispy;
 
-
-		void create_derived_font_textures();
+	void create_derived_font_textures();
 };
 
 enum InitDisplayFlag
@@ -75,30 +72,30 @@ enum struct InitDisplayFilterMode : int32_t {
 	NUM
 };
 
-class init_displayst
-{
- public:
+struct init_displayst {
+  int32_t max_interface_percentage = 100;
+  int32_t interface_scaling_desired_width = 170;
+  int32_t interface_scaling_desired_height = 64;
+  int32_t interface_scaling_percentage = 100;
   flagarrayst flag;
-  InitDisplayWindow windowed;
+
+  init_displayst(){
+		flag.set_size_on_flag_num(INIT_DISPLAY_FLAGNUM);
+		flag.add_flag(INIT_DISPLAY_FLAG_USE_GRAPHICS);
+		flag.add_flag(INIT_DISPLAY_FLAG_INTERFACE_SCALING_TO_DESIRED_HEIGHT_WIDTH);
+	}
+
+  InitDisplayWindow windowed = INIT_DISPLAY_WINDOW_TRUE;
 
   int grid_x, grid_y; // The *current* display grid size, kept up to date
-
   int desired_fullscreen_width, desired_fullscreen_height;
   int actual_fullscreen_width, actual_fullscreen_height;
   int desired_windowed_width, desired_windowed_height;
   int actual_windowed_width, actual_windowed_height;
-  int32_t max_interface_percentage;
 
-  int32_t interface_scaling_desired_width;
-  int32_t interface_scaling_desired_height;
-  int32_t interface_scaling_percentage;
+  char partial_print_count = 0;
 
-  
-  char partial_print_count;
-
-  InitDisplayFilterMode filter_mode;
-
-  init_displayst();
+  InitDisplayFilterMode filter_mode = InitDisplayFilterMode::AUTO;
 };
 
 enum InitMediaFlag
@@ -109,26 +106,17 @@ enum InitMediaFlag
 	INIT_MEDIA_FLAGNUM
 };
 
-class init_mediast
-{
-	public:
-		flagarrayst flag;
-		int32_t volume_master;
-		int32_t volume_music;
-		int32_t volume_ambience;
-		int32_t volume_sfx;
-		int32_t time_between_songs;
+struct init_mediast {
+	int32_t volume_master = 255;
+	int32_t volume_music = 255;
+	int32_t volume_ambience = 220;
+	int32_t volume_sfx = 255;
+	int32_t time_between_songs = 240;
+	flagarrayst flag;
 
-
-		init_mediast()
-			{
-			flag.set_size_on_flag_num(INIT_MEDIA_FLAGNUM);
-			volume_master=255;
-			volume_music=255;
-			volume_ambience=220;
-			volume_sfx=255;
-			time_between_songs=240;
-			}
+	init_mediast(){
+		flag.set_size_on_flag_num(INIT_MEDIA_FLAGNUM);
+	}
 };
 
 enum InitInputFlag
@@ -138,30 +126,19 @@ enum InitInputFlag
 	INIT_INPUT_FLAGNUM
 };
 
-class init_inputst
-{
- public:
-  int32_t hold_time;
-  int32_t repeat_time;
-  int32_t macro_time;
-  int32_t pause_zoom_no_interface_ms;
+struct init_inputst {
+  int32_t hold_time = 150;
+  int32_t repeat_time = 150;
+  int32_t macro_time = 75;
+  int32_t pause_zoom_no_interface_ms = 0;
+  int32_t zoom_speed = 10;
+  int32_t repeat_accel_start = 10;
+  int32_t repeat_accel_limit = 1;
   flagarrayst flag;
-  int32_t zoom_speed;
-  int32_t repeat_accel_start;
-  int32_t repeat_accel_limit;
   
-  init_inputst()
-    {
-      hold_time=150;
-      repeat_time=150;
-      macro_time=75;
-      pause_zoom_no_interface_ms=0;
-      flag.set_size_on_flag_num(INIT_INPUT_FLAGNUM);
-
-      zoom_speed = 10;
-      repeat_accel_start = 10;
-      repeat_accel_limit = 1;
-    }
+  init_inputst(){
+    flag.set_size_on_flag_num(INIT_INPUT_FLAGNUM);
+  }
 };
 
 enum InitWindowFlag
@@ -172,17 +149,14 @@ enum InitWindowFlag
 	INIT_WINDOW_FLAGNUM
 };
 
-class init_windowst
-{
-	public:
-		flagarrayst flag;
+struct init_windowst {
+	flagarrayst flag;
 
-		init_windowst()
-			{
-			flag.set_size_on_flag_num(INIT_WINDOW_FLAGNUM);
-				flag.add_flag(INIT_WINDOW_FLAG_VSYNC_OFF);
-				flag.add_flag(INIT_WINDOW_FLAG_TEXTURE_LINEAR);
-			}
+	init_windowst(){
+		flag.set_size_on_flag_num(INIT_WINDOW_FLAGNUM);
+		flag.add_flag(INIT_WINDOW_FLAG_VSYNC_OFF);
+		flag.add_flag(INIT_WINDOW_FLAG_TEXTURE_LINEAR);
+	}
 };
 
 enum InitLoadBarTextureType
@@ -203,139 +177,142 @@ typedef int32_t InitLoadBarTexture;
 #define INIT_FILTER_TEXTURENUM 30
 #define INIT_TABS_TEXTURENUM 30
 
-class initst
-{
-	public:
-		init_displayst display;
-		init_mediast media;
-		init_inputst input;
-		init_fontst font;
-		init_windowst window;
+struct initst {
 
-		//these are just used for save/load purposes
-		int32_t fps_cap;
-		int32_t gfps_cap;
+	init_displayst display;
+	init_mediast media;
+	init_inputst input;
+	init_fontst font;
+	init_windowst window;
 
-		long load_bar_texpos[INIT_LOAD_BAR_TEXTURENUM];
-		long intro_button_texpos[INIT_INTRO_BUTTON_TEXTURENUM];
-			int32_t texpos_neutral_intro_button[9];
-			int32_t texpos_confirm_intro_button[9];
-			int32_t texpos_cancel_intro_button[9];
-			int32_t texpos_selected_intro_button[9];
-			int32_t texpos_unselected_intro_button[9];
-			int32_t texpos_open_list_button[9];
-			int32_t texpos_increase_button[9];
-			int32_t texpos_decrease_button[9];
-			int32_t texpos_nullify_button[9];
-			int32_t texpos_left_arrow_button[9];
-			int32_t texpos_right_arrow_button[9];
-			int32_t texpos_up_arrow_button[9];
-			int32_t texpos_down_arrow_button[9];
-		long border_texpos[INIT_BORDER_TEXTURENUM];
-			int32_t texpos_border_nw;
-			int32_t texpos_border_n;
-			int32_t texpos_border_ne;
-			int32_t texpos_border_w;
-			int32_t texpos_border_interior;
-			int32_t texpos_border_e;
-			int32_t texpos_border_sw;
-			int32_t texpos_border_s;
-			int32_t texpos_border_se;
-			int32_t texpos_border_join_n;
-			int32_t texpos_border_join_s;
-			int32_t texpos_border_join_w;
-			int32_t texpos_border_join_e;
-			int32_t texpos_border_inside_nswe;
-			int32_t texpos_border_inside_nsw;
-			int32_t texpos_border_inside_nse;
-			int32_t texpos_border_inside_nwe;
-			int32_t texpos_border_inside_swe;
-			int32_t texpos_border_inside_ns;
-			int32_t texpos_border_inside_we;
-		long scrollbar_texpos[INIT_SCROLLBAR_TEXTURENUM];
-			int32_t texpos_scrollbar[2][3];
-			int32_t texpos_scrollbar_up_hover[2];
-			int32_t texpos_scrollbar_up_pressed[2];
-			int32_t texpos_scrollbar_down_hover[2];
-			int32_t texpos_scrollbar_down_pressed[2];
-			int32_t texpos_scrollbar_small_scroller[2][2];
-			int32_t texpos_scrollbar_small_scroller_hover[2][2];
-			int32_t texpos_scrollbar_top_scroller[2];
-			int32_t texpos_scrollbar_top_scroller_hover[2];
-			int32_t texpos_scrollbar_bottom_scroller[2];
-			int32_t texpos_scrollbar_bottom_scroller_hover[2];
-			int32_t texpos_scrollbar_blank_scroller[2];
-			int32_t texpos_scrollbar_blank_scroller_hover[2];
-			int32_t texpos_scrollbar_center_scroller[2];
-			int32_t texpos_scrollbar_center_scroller_hover[2];
-			int32_t texpos_scrollbar_offcenter_scroller[2][2];
-			int32_t texpos_scrollbar_offcenter_scroller_hover[2][2];
-		long filter_texpos[INIT_FILTER_TEXTURENUM];
-			int32_t texpos_button_filter[6][3];
-			int32_t texpos_button_filter_name[4][3];
-		long tabs_texpos[INIT_TABS_TEXTURENUM];
-			int32_t texpos_tab_unselected[5][2];
-			int32_t texpos_tab_selected[5][2];
+	//these are just used for save/load purposes
+	int32_t fps_cap;
+	int32_t gfps_cap;
 
-		//classic basic interface
-		long classic_load_bar_texpos[INIT_LOAD_BAR_TEXTURENUM];
-		int32_t classic_texpos_neutral_intro_button[9];
-		int32_t classic_texpos_confirm_intro_button[9];
-		int32_t classic_texpos_cancel_intro_button[9];
-		int32_t classic_texpos_selected_intro_button[9];
-		int32_t classic_texpos_unselected_intro_button[9];
-		int32_t classic_texpos_open_list_button[9];
-		int32_t classic_texpos_increase_button[9];
-		int32_t classic_texpos_decrease_button[9];
-		int32_t classic_texpos_nullify_button[9];
-		int32_t classic_texpos_left_arrow_button[9];
-		int32_t classic_texpos_right_arrow_button[9];
-		int32_t classic_texpos_up_arrow_button[9];
-		int32_t classic_texpos_down_arrow_button[9];
-		int32_t classic_texpos_border_nw;
-		int32_t classic_texpos_border_n;
-		int32_t classic_texpos_border_ne;
-		int32_t classic_texpos_border_w;
-		int32_t classic_texpos_border_interior;
-		int32_t classic_texpos_border_e;
-		int32_t classic_texpos_border_sw;
-		int32_t classic_texpos_border_s;
-		int32_t classic_texpos_border_se;
-		int32_t classic_texpos_border_join_n;
-		int32_t classic_texpos_border_join_s;
-		int32_t classic_texpos_border_join_w;
-		int32_t classic_texpos_border_join_e;
-		int32_t classic_texpos_border_inside_nswe;
-		int32_t classic_texpos_border_inside_nsw;
-		int32_t classic_texpos_border_inside_nse;
-		int32_t classic_texpos_border_inside_nwe;
-		int32_t classic_texpos_border_inside_swe;
-		int32_t classic_texpos_border_inside_ns;
-		int32_t classic_texpos_border_inside_we;
-		int32_t classic_texpos_scrollbar[2][3];
-		int32_t classic_texpos_scrollbar_up_hover[2];
-		int32_t classic_texpos_scrollbar_up_pressed[2];
-		int32_t classic_texpos_scrollbar_down_hover[2];
-		int32_t classic_texpos_scrollbar_down_pressed[2];
-		int32_t classic_texpos_scrollbar_small_scroller[2][2];
-		int32_t classic_texpos_scrollbar_small_scroller_hover[2][2];
-		int32_t classic_texpos_scrollbar_top_scroller[2];
-		int32_t classic_texpos_scrollbar_top_scroller_hover[2];
-		int32_t classic_texpos_scrollbar_bottom_scroller[2];
-		int32_t classic_texpos_scrollbar_bottom_scroller_hover[2];
-		int32_t classic_texpos_scrollbar_blank_scroller[2];
-		int32_t classic_texpos_scrollbar_blank_scroller_hover[2];
-		int32_t classic_texpos_scrollbar_center_scroller[2];
-		int32_t classic_texpos_scrollbar_center_scroller_hover[2];
-		int32_t classic_texpos_scrollbar_offcenter_scroller[2][2];
-		int32_t classic_texpos_scrollbar_offcenter_scroller_hover[2][2];
-		int32_t classic_texpos_button_filter[6][3];
-		int32_t classic_texpos_button_filter_name[4][3];
-		int32_t classic_texpos_tab_unselected[5][2];
-		int32_t classic_texpos_tab_selected[5][2];
+	long load_bar_texpos[INIT_LOAD_BAR_TEXTURENUM];
+	long intro_button_texpos[INIT_INTRO_BUTTON_TEXTURENUM];
+	int32_t texpos_neutral_intro_button[9];
+	int32_t texpos_confirm_intro_button[9];
+	int32_t texpos_cancel_intro_button[9];
+	int32_t texpos_selected_intro_button[9];
+	int32_t texpos_unselected_intro_button[9];
+	int32_t texpos_open_list_button[9];
+	int32_t texpos_increase_button[9];
+	int32_t texpos_decrease_button[9];
+	int32_t texpos_nullify_button[9];
+	int32_t texpos_left_arrow_button[9];
+	int32_t texpos_right_arrow_button[9];
+	int32_t texpos_up_arrow_button[9];
+	int32_t texpos_down_arrow_button[9];
 
-		void begin();
-		void swap_basic_sets();
+	long border_texpos[INIT_BORDER_TEXTURENUM];
+	int32_t texpos_border_nw;
+	int32_t texpos_border_n;
+	int32_t texpos_border_ne;
+	int32_t texpos_border_w;
+	int32_t texpos_border_interior;
+	int32_t texpos_border_e;
+	int32_t texpos_border_sw;
+	int32_t texpos_border_s;
+	int32_t texpos_border_se;
+	int32_t texpos_border_join_n;
+	int32_t texpos_border_join_s;
+	int32_t texpos_border_join_w;
+	int32_t texpos_border_join_e;
+	int32_t texpos_border_inside_nswe;
+	int32_t texpos_border_inside_nsw;
+	int32_t texpos_border_inside_nse;
+	int32_t texpos_border_inside_nwe;
+	int32_t texpos_border_inside_swe;
+	int32_t texpos_border_inside_ns;
+	int32_t texpos_border_inside_we;
+
+	long scrollbar_texpos[INIT_SCROLLBAR_TEXTURENUM];
+	int32_t texpos_scrollbar[2][3];
+	int32_t texpos_scrollbar_up_hover[2];
+	int32_t texpos_scrollbar_up_pressed[2];
+	int32_t texpos_scrollbar_down_hover[2];
+	int32_t texpos_scrollbar_down_pressed[2];
+	int32_t texpos_scrollbar_small_scroller[2][2];
+	int32_t texpos_scrollbar_small_scroller_hover[2][2];
+	int32_t texpos_scrollbar_top_scroller[2];
+	int32_t texpos_scrollbar_top_scroller_hover[2];
+	int32_t texpos_scrollbar_bottom_scroller[2];
+	int32_t texpos_scrollbar_bottom_scroller_hover[2];
+	int32_t texpos_scrollbar_blank_scroller[2];
+	int32_t texpos_scrollbar_blank_scroller_hover[2];
+	int32_t texpos_scrollbar_center_scroller[2];
+	int32_t texpos_scrollbar_center_scroller_hover[2];
+	int32_t texpos_scrollbar_offcenter_scroller[2][2];
+	int32_t texpos_scrollbar_offcenter_scroller_hover[2][2];
+
+	long filter_texpos[INIT_FILTER_TEXTURENUM];
+	int32_t texpos_button_filter[6][3];
+	int32_t texpos_button_filter_name[4][3];
+	
+	long tabs_texpos[INIT_TABS_TEXTURENUM];
+	int32_t texpos_tab_unselected[5][2];
+	int32_t texpos_tab_selected[5][2];
+
+	//classic basic interface
+	long classic_load_bar_texpos[INIT_LOAD_BAR_TEXTURENUM];
+	int32_t classic_texpos_neutral_intro_button[9];
+	int32_t classic_texpos_confirm_intro_button[9];
+	int32_t classic_texpos_cancel_intro_button[9];
+	int32_t classic_texpos_selected_intro_button[9];
+	int32_t classic_texpos_unselected_intro_button[9];
+	int32_t classic_texpos_open_list_button[9];
+	int32_t classic_texpos_increase_button[9];
+	int32_t classic_texpos_decrease_button[9];
+	int32_t classic_texpos_nullify_button[9];
+	int32_t classic_texpos_left_arrow_button[9];
+	int32_t classic_texpos_right_arrow_button[9];
+	int32_t classic_texpos_up_arrow_button[9];
+	int32_t classic_texpos_down_arrow_button[9];
+	int32_t classic_texpos_border_nw;
+	int32_t classic_texpos_border_n;
+	int32_t classic_texpos_border_ne;
+	int32_t classic_texpos_border_w;
+	int32_t classic_texpos_border_interior;
+	int32_t classic_texpos_border_e;
+	int32_t classic_texpos_border_sw;
+	int32_t classic_texpos_border_s;
+	int32_t classic_texpos_border_se;
+	int32_t classic_texpos_border_join_n;
+	int32_t classic_texpos_border_join_s;
+	int32_t classic_texpos_border_join_w;
+	int32_t classic_texpos_border_join_e;
+	int32_t classic_texpos_border_inside_nswe;
+	int32_t classic_texpos_border_inside_nsw;
+	int32_t classic_texpos_border_inside_nse;
+	int32_t classic_texpos_border_inside_nwe;
+	int32_t classic_texpos_border_inside_swe;
+	int32_t classic_texpos_border_inside_ns;
+	int32_t classic_texpos_border_inside_we;
+	int32_t classic_texpos_scrollbar[2][3];
+	int32_t classic_texpos_scrollbar_up_hover[2];
+	int32_t classic_texpos_scrollbar_up_pressed[2];
+	int32_t classic_texpos_scrollbar_down_hover[2];
+	int32_t classic_texpos_scrollbar_down_pressed[2];
+	int32_t classic_texpos_scrollbar_small_scroller[2][2];
+	int32_t classic_texpos_scrollbar_small_scroller_hover[2][2];
+	int32_t classic_texpos_scrollbar_top_scroller[2];
+	int32_t classic_texpos_scrollbar_top_scroller_hover[2];
+	int32_t classic_texpos_scrollbar_bottom_scroller[2];
+	int32_t classic_texpos_scrollbar_bottom_scroller_hover[2];
+	int32_t classic_texpos_scrollbar_blank_scroller[2];
+	int32_t classic_texpos_scrollbar_blank_scroller_hover[2];
+	int32_t classic_texpos_scrollbar_center_scroller[2];
+	int32_t classic_texpos_scrollbar_center_scroller_hover[2];
+	int32_t classic_texpos_scrollbar_offcenter_scroller[2][2];
+	int32_t classic_texpos_scrollbar_offcenter_scroller_hover[2][2];
+	int32_t classic_texpos_button_filter[6][3];
+	int32_t classic_texpos_button_filter_name[4][3];
+	int32_t classic_texpos_tab_unselected[5][2];
+	int32_t classic_texpos_tab_selected[5][2];
+
+	void begin();
+	void swap_basic_sets();
 };
 
 extern initst init;

--- a/g_src/textlines.h
+++ b/g_src/textlines.h
@@ -1,11 +1,9 @@
 #ifndef TEXTLINES_H
 #define TEXTLINES_H
 
-struct textlinesst
-{
+struct textlinesst {
+
 	stringvectst text;
-
-
 
 	void load_raw_to_lines(const char *filename);
 

--- a/g_src/texture_handler.h
+++ b/g_src/texture_handler.h
@@ -3,28 +3,21 @@
 
 #include "textlines.h"
 
-struct palette_pagest
-{
+struct palette_pagest {
+
 	string token;
 
 	string graphics_dir;
 
 	string filename;
 
-
-	int32_t default_row;
+	int32_t default_row = -1;
 	stringvectst color_token;
-		svector<int32_t> color_row;//linked
-
-
-	palette_pagest()
-		{
-		default_row=-1;
-		}
+	svector<int32_t> color_row;//linked
 };
 
-struct tile_pagest
-{
+struct tile_pagest {
+
 	string token;
 
 	string graphics_dir;
@@ -40,52 +33,43 @@ struct tile_pagest
 	svector<long> texpos_gs;
 	svector<long> datapos_gs;
 
-	char loaded;
-
-
-
-	tile_pagest()
-		{
-		loaded=0;
-		}
+	char loaded = 0;
 
 	void load_graphics();
 	void refresh_graphics();
 };
 
-class texture_handlerst
-{
-	public:
-		svector<tile_pagest *> page;
-		svector<palette_pagest *> palette;
+struct texture_handlerst {
+	// are you sure the svector is the right type here? not a map?
+	svector<tile_pagest *> page;
+	svector<palette_pagest *> palette;
 
+	void clean();
+	void adopt_new_lines(textlinesst &lines,const string &graphics_dir);
 
-		void clean();
-		void adopt_new_lines(textlinesst &lines,const string &graphics_dir);
+	~texture_handlerst()
+		{
+		clean();
+		}
 
-		~texture_handlerst()
+	tile_pagest *get_tile_page_by_token(string &tk)
+		{
+		int32_t t;
+		for(t=0;t<page.size();t++)
 			{
-			clean();
+			if(page[t]->token==tk)return page[t];
 			}
-
-		tile_pagest *get_tile_page_by_token(string &tk)
+		return NULL;
+		}
+	palette_pagest *get_palette_page_by_token(string &tk)
+		{
+		int32_t t;
+		for(t=0;t<palette.size();t++)
 			{
-			int32_t t;
-			for(t=0;t<page.size();t++)
-				{
-				if(page[t]->token==tk)return page[t];
-				}
-			return NULL;
+			if(palette[t]->token==tk)return palette[t];
 			}
-		palette_pagest *get_palette_page_by_token(string &tk)
-			{
-			int32_t t;
-			for(t=0;t<palette.size();t++)
-				{
-				if(palette[t]->token==tk)return palette[t];
-				}
-			return NULL;
-			}
+		return NULL;
+		}
 };
 
 #endif


### PR DESCRIPTION
This PR takes all classes with exclusively public members and redefines them as structs. Note that this does not affect inheritance and is therefore a safe change.

Additionally, it removes some redundant constructors which are just duplicating code and additionally help in legibility detecting non-initialized members, e.g. `ViewBase.h:25`.

I didn't do this everywhere, because some of the large pointer-wrapper classes should probably use dedicated fold-expressions or similar to zero the contiguous memory.